### PR TITLE
[ISSUE-70] Error during create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - open the terminal;
 - `npx create-react-app PROJECT_NAME --template ui5-webcomponents-react-seed`;
 - cd into `PROJECT_NAME`;
+- run `node post_create.js` to add **Husky** and move some dependencies to devDependencies (both are limitations of `create-react-app`)
 - (no need to run `yarn install` since it already installs it for you);
 - run the available scripts.
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eject": "react-scripts eject",
     "push:pre": "npm-run-all --parallel test:ci lint prettier",
     "publish:clean": "rm -rf ./template/src ./template/server ./template/.vscode ./template/public && rm -f ./template/.editorconfig ./template/.env.development ./template/.env.production ./template/.eslintignore ./template/.eslintrc.js ./template/.prettierrc ./template/commitlint.config.js ./template/jest.config.json ./template/PULL_REQUEST_TEMPLATE.md ./template/README.md ./template/webpack.config.js",
-    "publish:copy": "cp -a ./src/. template/src && cp -a ./server/. template/server && cp -a ./.vscode/. template/.vscode && cp -a ./public/. template/public && cp .editorconfig .env.development .env.production .eslintignore .eslintrc.js .prettierrc commitlint.config.js jest.config.json PULL_REQUEST_TEMPLATE.md README.md webpack.config.js template/",
+    "publish:copy": "cp -a ./src/. template/src && cp -a ./server/. template/server && cp -a ./.vscode/. template/.vscode && cp -a ./public/. template/public && cp .editorconfig .env.development .env.production .eslintignore .eslintrc.js .prettierrc commitlint.config.js jest.config.json PULL_REQUEST_TEMPLATE.md README.md webpack.config.js post_create.js template/",
     "publish:prepare": "npm-run-all publish:clean publish:copy"
   },
   "browserslist": {

--- a/post_create.js
+++ b/post_create.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+
+const PACKAGE_FILE = 'package.json';
+const UTF_8 = 'utf-8';
+
+const husky = {
+  husky: {
+    hooks: {
+      'pre-push': 'npm run push:pre',
+      'commit-msg': 'commitlint -E HUSKY_GIT_PARAMS',
+      'prepare-commit-msg': 'exec < /dev/tty && true',
+    },
+  },
+};
+
+const DEV_DEPENDENCIES = [
+  '@babel/plugin-proposal-class-properties',
+  '@commitlint/cli',
+  '@commitlint/config-conventional',
+  '@testing-library/jest-dom',
+  '@testing-library/react',
+  '@testing-library/user-event',
+  '@types/jest',
+  'env-cmd',
+  'eslint-config-prettier',
+  'eslint-plugin-prettier',
+  'husky',
+  'jest-environment-jsdom-sixteen',
+  'json-server',
+  'msw',
+  'nodemon',
+  'npm-run-all',
+  'prettier',
+];
+
+const deleteThisScript = () => {
+  console.log('\nAuto deleting this script');
+  fs.unlink('post_create.js', (err) => {
+    if (err) throw err;
+  });
+};
+
+const moveDevDependencies = (oldContent, devDependencies = {}) => {
+  for (let dependency in oldContent.dependencies) {
+    if (DEV_DEPENDENCIES.includes(dependency)) {
+      console.log(`Moving ${dependency} to devDependencies`);
+      devDependencies[dependency] = oldContent.dependencies[dependency];
+      delete oldContent.dependencies[dependency];
+    }
+  }
+  return devDependencies;
+};
+
+fs.readFile(PACKAGE_FILE, UTF_8, (err, data) => {
+  if (err) throw err;
+
+  const oldContent = JSON.parse(data);
+  if (oldContent.husky && oldContent.devDependencies) {
+    console.log(`Your ${PACKAGE_FILE} is already correct.`);
+    deleteThisScript();
+    return;
+  }
+
+  const devDependencies = moveDevDependencies(oldContent);
+
+  console.log(`\nAdding husky and devDependencies to new ${PACKAGE_FILE}`);
+  const newContent = { ...oldContent, husky, devDependencies };
+  const newFileContent = JSON.stringify(newContent, null, 2);
+
+  console.log(`\nWriting ${PACKAGE_FILE} to disk`);
+  fs.writeFile(PACKAGE_FILE, newFileContent, UTF_8, (err) => {
+    if (err) throw err;
+    deleteThisScript();
+  });
+});

--- a/template.json
+++ b/template.json
@@ -70,13 +70,6 @@
       "transformIgnorePatterns": [
         "node_modules/(?!(@ui5|lit-html)).*\\.js$"
       ]
-    },
-    "husky": {
-      "hooks": {
-        "pre-push": "npm run push:pre",
-        "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-        "prepare-commit-msg": "exec < /dev/tty && true"
-      }
     }
   }
 }


### PR DESCRIPTION
## Description

Initially investigating the error of this #70.

The error happens because we have **husky** in our `template.json` which causes the first commit to fail. To solve this is necessary to perform a manual step after using `create-react-app`. Since we'd already need to perform a manual step to suppress the error I added a node script that:
- Add husky to `package.json`
- Move the development dependencies to **devDependencies** on `package.json`
- Delete itself after execution

Now projects that use this seed can use `yarn install --prod` to save time during deployment.

## Dependency

N/A

## Config

Are you adding a configuration file?

- [X] Have you updated the `publish` scripts?

Are you adding a new feature

- [X] Have you updated the `README.md`?

## Testing

`npx create-react-app PROJEC_NAME --template file:ui5-webcomponents-react-seed` and then follow the **README.md**.

## Automated Tests

- [ ] Select this if your code has automated Tests for it.

## References

- #70 