### PR TITLE
feat: add more react-query examples

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { BrowserRouter } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
+import { ReactQueryCacheProvider, QueryCache } from 'react-query';
 import { ReactQueryDevtools } from 'react-query-devtools';
 
 import ErrorBoundary from './pages/Fallback/ErrorBoundary';
@@ -10,18 +11,22 @@ import Routes from './routes/Routes';
 
 import './App.css';
 
+const queryCache = new QueryCache();
+
 function App() {
   const { t } = useTranslation();
 
   return (
-    <BrowserRouter>
-      <ReactQueryDevtools initialIsOpen={false} />
-      <Helmet title={t('helmet.title.app')} />
-      <Shell title={t('shell.title')} />
-      <ErrorBoundary>
-        <Routes />
-      </ErrorBoundary>
-    </BrowserRouter>
+    <ReactQueryCacheProvider queryCache={queryCache}>
+      <BrowserRouter>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <Helmet title={t('helmet.title.app')} />
+        <Shell title={t('shell.title')} />
+        <ErrorBoundary>
+          <Routes />
+        </ErrorBoundary>
+      </BrowserRouter>
+    </ReactQueryCacheProvider>
   );
 }
 

--- a/src/hooks/useAuthority.js
+++ b/src/hooks/useAuthority.js
@@ -3,9 +3,9 @@ import Constants from '../util/Constants';
 import APIProvider from '../util/api/url/APIProvider';
 
 export function useHasAccess(allowedAuthorities, authorityKey) {
-  const { data, status } = useGet(Constants.REACT_QUERY.KEYS.RQ_GET_USER_LOGGED, APIProvider.getUrl('GET_USER_LOGGED'), null);
+  const { data, isSuccess } = useGet(Constants.REACT_QUERY.KEYS.RQ_GET_USER_LOGGED, APIProvider.getUrl('GET_USER_LOGGED'), null);
 
-  if (status !== Constants.REACT_QUERY.CODES.SUCCESS) {
+  if (!isSuccess) {
     return null;
   }
 

--- a/src/pages/Todo/Add/AddTodoForm.js
+++ b/src/pages/Todo/Add/AddTodoForm.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Form, Formik } from 'formik';
+import { Button, ButtonDesign, FlexBox, FlexBoxDirection, FlexBoxAlignItems } from '@ui5/webcomponents-react';
+import { useQueryCache } from 'react-query';
+
+import APIProvider from '../../../util/api/url/APIProvider';
+import Constants from '../../../util/Constants';
+import { usePost } from '../../../hooks/useRequest';
+
+import TodoForm from '../Form/TodoForm';
+import TodoFormValidationSchema from '../Form/TodoFormValidationSchema';
+import FormData from '../Form/Data';
+
+const styles = {
+  flexBox: {
+    width: '100%',
+    margin: '10px 0',
+  },
+  buttons: {
+    marginRight: '10px',
+  },
+  form: {
+    margin: '0 15px',
+  },
+};
+
+const AddTodoForm = ({ dialogClose }) => {
+  const queryCache = useQueryCache();
+  const [addTodo] = usePost({
+    url: APIProvider.getUrl('CREATE_TODO'),
+    mutationOptions: {
+      onSuccess: () => {
+        queryCache.invalidateQueries([Constants.REACT_QUERY.KEYS.RQ_GET_TODO_LIST]);
+      },
+    },
+  });
+
+  const onSubmitEditForm = async (values, actions) => {
+    actions.setSubmitting(true);
+    await addTodo({ ...values, isCompleted: values.completed });
+    actions.setSubmitting(false);
+    actions.resetForm(true);
+    dialogClose();
+  };
+
+  return (
+    <Formik enableReinitialize initialValues={FormData} validationSchema={TodoFormValidationSchema} onSubmit={onSubmitEditForm}>
+      {({ isSubmitting, handleSubmit }) => (
+        <Form style={styles.form}>
+          <TodoForm />
+          <FlexBox direction={FlexBoxDirection.RowReverse} alignItems={FlexBoxAlignItems.Center} style={styles.flexBox}>
+            <Button type="submit" disabled={isSubmitting} design={ButtonDesign.Emphasized} icon="paper-plane" style={styles.buttons} onClick={handleSubmit}>
+              Submit
+            </Button>
+            <Button style={styles.buttons} onClick={dialogClose}>
+              Cancel
+            </Button>
+          </FlexBox>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default AddTodoForm;

--- a/src/pages/Todo/Edit/TodoEdit.js
+++ b/src/pages/Todo/Edit/TodoEdit.js
@@ -9,23 +9,16 @@ import TodoEditForm from './TodoEditForm';
 import Constants from '../../../util/Constants';
 import APIProvider from '../../../util/api/url/APIProvider';
 
-const onSubmitEditForm = (values, actions) => {
-  actions.setSubmitting(true);
-  alert(JSON.stringify(values, null, 2));
-  actions.resetForm(true);
-  actions.setSubmitting(false);
-};
-
 export default function TodoEdit({ match }) {
-  const { data, status } = useGet(Constants.REACT_QUERY.KEYS.GET_TODO_BY_ID, APIProvider.getUrl('GET_TODO_BY_ID', [{ value: match.params.id }]));
+  const { data, isLoading, isSuccess } = useGet(Constants.REACT_QUERY.KEYS.GET_TODO_BY_ID, APIProvider.getUrl('GET_TODO_BY_ID', [{ value: match.params.id }]));
 
   return (
     <>
       <Helmet title="Edit - TodoList App" />
       <NavBack />
       <CenteredContent>
-        {status === Constants.REACT_QUERY.CODES.LOADING && <Spinner />}
-        {status === Constants.REACT_QUERY.CODES.SUCCESS && <TodoEditForm data={data.data.todos} onSubmitHandler={onSubmitEditForm} />}
+        {isLoading && <Spinner />}
+        {isSuccess && <TodoEditForm data={data} />}
       </CenteredContent>
     </>
   );

--- a/src/pages/Todo/Edit/TodoEditForm.js
+++ b/src/pages/Todo/Edit/TodoEditForm.js
@@ -1,13 +1,15 @@
 import React from 'react';
+import { Form, Formik } from 'formik';
+import { useHistory } from 'react-router-dom';
+import { Button, ButtonDesign, FlexBox, FlexBoxAlignItems, FlexBoxDirection } from '@ui5/webcomponents-react';
 
-import { Field, Form, Formik } from 'formik';
-import { Button, ButtonDesign, FlexBox, FlexBoxAlignItems, FlexBoxDirection, InputType } from '@ui5/webcomponents-react';
-import Input from '../../../components/Form/Input/Input';
-import Switch from '../../../components/Form/Switch/Switch';
-import TextArea from '../../../components/Form/TextArea/TextArea';
-import Select from '../../../components/Form/Select/Select';
-import TodoEditFormValidationSchema from './TodoEditFormValidationSchema';
 import NavBack, { NavBackIcon } from '../../../components/NavBack/NavBack';
+import APIProvider from '../../../util/api/url/APIProvider';
+import BrowserProvider from '../../../util/browser/BrowserProvider';
+import { usePut } from '../../../hooks/useRequest';
+
+import TodoForm from '../Form/TodoForm';
+import TodoFormValidationSchema from '../Form/TodoFormValidationSchema';
 
 const style = {
   putWrapperUp: {
@@ -15,44 +17,33 @@ const style = {
   },
 };
 
-const typeOptions = [
-  { id: 'WORK', text: 'Work' },
-  { id: 'PERSONAL', text: 'Personal' },
-  { id: 'SCHOOL', text: 'School' },
-];
+export default function TodoEditForm({ data }) {
+  const history = useHistory();
+  const [editTodo] = usePut({
+    url: APIProvider.getUrl('UPDATE_TODO', [{ value: data.id }]),
+  });
 
-const priorityOptions = [
-  { id: 'LOW', text: 'Low' },
-  { id: 'MEDIUM', text: 'Medium' },
-  { id: 'HIGH', text: 'High' },
-];
+  const onSubmitEditForm = async (values, actions) => {
+    actions.setSubmitting(true);
+    await editTodo({ ...values, isCompleted: values.completed });
+    actions.setSubmitting(false);
+    actions.resetForm(true);
+    history.push(BrowserProvider.getUrl('TODO_LIST'));
+  };
 
-export default function TodoEditForm({ data, onSubmitHandler }) {
   return (
     <div style={style.putWrapperUp}>
       <h1>Todo Edit Form</h1>
-      <Formik enableReinitialize initialValues={data} validationSchema={TodoEditFormValidationSchema} onSubmit={onSubmitHandler}>
+      <Formik enableReinitialize initialValues={data} validationSchema={TodoFormValidationSchema} onSubmit={onSubmitEditForm}>
         {({ isSubmitting, handleSubmit }) => (
           <Form>
-            <div>
-              <h3>Basic Info</h3>
-              <Field labelText="Name" name="name" required placeholder="Name goes here" type={InputType.Text} component={Input} />
-              <Field labelText="Description" name="description" required placeholder="Add your description here" rows={5} component={TextArea} />
-              <Field labelText="Completed" name="completed" required component={Switch} graphical={true} />
-            </div>
-            <div>
-              <h3>Custom Info</h3>
-              <Field labelText="Priority" name="priority" required component={Select} options={priorityOptions} />
-              <Field labelText="Type" name="type" required component={Select} options={typeOptions} />
-            </div>
-            <div>
-              <FlexBox direction={FlexBoxDirection.RowReverse} alignItems={FlexBoxAlignItems.Center}>
-                <Button type="submit" disabled={isSubmitting} onClick={handleSubmit} design={ButtonDesign.Emphasized} icon="paper-plane">
-                  Submit
-                </Button>
-                <NavBack text="Cancel" icon={NavBackIcon.NONE} />
-              </FlexBox>
-            </div>
+            <TodoForm />
+            <FlexBox direction={FlexBoxDirection.RowReverse} alignItems={FlexBoxAlignItems.Center}>
+              <Button type="submit" disabled={isSubmitting} onClick={handleSubmit} design={ButtonDesign.Emphasized} icon="paper-plane">
+                Submit
+              </Button>
+              <NavBack text="Cancel" icon={NavBackIcon.NONE} />
+            </FlexBox>
           </Form>
         )}
       </Formik>

--- a/src/pages/Todo/Form/Data.js
+++ b/src/pages/Todo/Form/Data.js
@@ -1,0 +1,10 @@
+import TypeOptions from './TypeOptions';
+import PriorityOptions from './PriorityOptions';
+
+export default {
+  name: '',
+  description: '',
+  completed: false,
+  priority: PriorityOptions[0].id,
+  type: TypeOptions[0].id,
+};

--- a/src/pages/Todo/Form/PriorityOptions.js
+++ b/src/pages/Todo/Form/PriorityOptions.js
@@ -1,0 +1,5 @@
+export default [
+  { id: 'LOW', text: 'Low' },
+  { id: 'MEDIUM', text: 'Medium' },
+  { id: 'HIGH', text: 'High' },
+];

--- a/src/pages/Todo/Form/TodoForm.js
+++ b/src/pages/Todo/Form/TodoForm.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Field } from 'formik';
+import { InputType } from '@ui5/webcomponents-react';
+
+import Input from '../../../components/Form/Input/Input';
+import Switch from '../../../components/Form/Switch/Switch';
+import TextArea from '../../../components/Form/TextArea/TextArea';
+import Select from '../../../components/Form/Select/Select';
+
+import TypeOptions from './TypeOptions';
+import PriorityOptions from './PriorityOptions';
+
+const TodoForm = () => (
+  <>
+    <div>
+      <h3>Basic Info</h3>
+      <Field labelText="Name" name="name" required placeholder="Name goes here" type={InputType.Text} component={Input} />
+      <Field labelText="Description" name="description" required placeholder="Add your description here" rows={5} component={TextArea} />
+      <Field labelText="Completed" name="completed" required component={Switch} graphical={true} />
+    </div>
+    <div>
+      <h3>Custom Info</h3>
+      <Field labelText="Priority" name="priority" required component={Select} options={PriorityOptions} />
+      <Field labelText="Type" name="type" required component={Select} options={TypeOptions} />
+    </div>
+  </>
+);
+
+export default TodoForm;

--- a/src/pages/Todo/Form/TodoFormValidationSchema.js
+++ b/src/pages/Todo/Form/TodoFormValidationSchema.js
@@ -1,9 +1,9 @@
 import * as yup from 'yup';
 
-const TodoEditFormValidationSchema = yup.object({
+const TodoFormValidationSchema = yup.object({
   name: yup.string().required().max(25, 'This field must have maximum 25 characters'),
   description: yup.string().required().max(255, 'This field must have maximum 255 characters'),
   completed: yup.boolean(),
 });
 
-export default TodoEditFormValidationSchema;
+export default TodoFormValidationSchema;

--- a/src/pages/Todo/Form/TypeOptions.js
+++ b/src/pages/Todo/Form/TypeOptions.js
@@ -1,0 +1,5 @@
+export default [
+  { id: 'WORK', text: 'Work' },
+  { id: 'PERSONAL', text: 'Personal' },
+  { id: 'SCHOOL', text: 'School' },
+];

--- a/src/pages/Todo/List/TodoListPaginatedItems.js
+++ b/src/pages/Todo/List/TodoListPaginatedItems.js
@@ -1,42 +1,53 @@
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { usePaginatedGet } from '../../../hooks/useRequest';
 
-import { List } from '@ui5/webcomponents-react/lib/List';
-import { StandardListItem } from '@ui5/webcomponents-react/lib/StandardListItem';
-import { Spinner } from '@ui5/webcomponents-react';
+import { Spinner, Button, FlexBox, FlexBoxAlignItems, Dialog, StandardListItem, List } from '@ui5/webcomponents-react';
 import { Pagination } from '../../../components/Pagination/Pagination';
 
 import Constants from '../../../util/Constants';
 import BrowserProvider from '../../../util/browser/BrowserProvider';
 import APIProvider from '../../../util/api/url/APIProvider';
+import AddTodoForm from '../Add/AddTodoForm';
 
 export default function TodoListPaginatedItems() {
   const history = useHistory();
   const [page, setPage] = useState(0);
-  const { resolvedData, status } = usePaginatedGet(Constants.REACT_QUERY.KEYS.RQ_GET_TODO_LIST, page, APIProvider.getUrl('GET_TODO_LIST'));
+  const dialogRef = useRef();
+  const { resolvedData, isLoading } = usePaginatedGet(Constants.REACT_QUERY.KEYS.RQ_GET_TODO_LIST, page, APIProvider.getUrl('GET_TODO_LIST'));
+  const onOpenDialogClick = useCallback(() => {
+    dialogRef.current.open();
+  }, [dialogRef]);
+  const closeDialog = useCallback(() => {
+    dialogRef.current.close();
+  }, [dialogRef]);
 
   const redirectToEditPage = (e) => {
     history.push(BrowserProvider.getUrl('TODO_EDIT', [{ value: e.detail.item.dataset.id }]));
   };
 
+  if (isLoading) {
+    return <Spinner />;
+  }
+
   return (
-    <div>
-      {status === Constants.REACT_QUERY.CODES.LOADING ? (
-        <Spinner />
-      ) : (
-        <>
-          <h3>{`Records (${resolvedData.numberOfElements} / ${resolvedData.totalElements})`}</h3>
-          <List onItemClick={(e) => redirectToEditPage(e)}>
-            {resolvedData.content.map((todo, index) => (
-              <StandardListItem data-id={todo.id} key={index} iconEnd={false} info={todo.description} infoState="None" selected={false}>
-                {todo.name}
-              </StandardListItem>
-            ))}
-          </List>
-          <Pagination numberOfElements={resolvedData.numberOfElements} totalPages={resolvedData.totalPages} selectedPage={resolvedData.number} setPage={(params) => setPage(params)} />
-        </>
-      )}
-    </div>
+    <>
+      <FlexBox alignItems={FlexBoxAlignItems.Center}>
+        <h3>{`Records (${resolvedData.numberOfElements} / ${resolvedData.totalElements})`}</h3>
+        <Button icon="add" style={{ marginLeft: '10px' }} onClick={onOpenDialogClick} />
+      </FlexBox>
+
+      <List onItemClick={(e) => redirectToEditPage(e)}>
+        {resolvedData.content.map((todo, index) => (
+          <StandardListItem data-id={todo.id} key={index} iconEnd={false} info={todo.description} infoState="None" selected={false}>
+            {todo.name}
+          </StandardListItem>
+        ))}
+      </List>
+      <Pagination numberOfElements={resolvedData.numberOfElements} totalPages={resolvedData.totalPages} selectedPage={resolvedData.number} setPage={(params) => setPage(params)} />
+      <Dialog ref={dialogRef} headerText="Add">
+        <AddTodoForm dialogClose={closeDialog} />
+      </Dialog>
+    </>
   );
 }

--- a/src/util/api/url/APIProvider.js
+++ b/src/util/api/url/APIProvider.js
@@ -4,6 +4,8 @@ const URLs = {
   GET_USER_LOGGED: '/v1/user/logged',
   GET_TODO_BY_ID: '/v1/todo/:id',
   GET_TODO_LIST: '/v1/todo/all',
+  CREATE_TODO: '/v1/todo',
+  UPDATE_TODO: '/v1/todo/:id',
 };
 
 export default {


### PR DESCRIPTION
## Description

Add more operations showing how to use react-query. 

### This breaks the integration with `json-server`.

`json-server` is not capable of handling the creation of new To-dos and paginating them as we would like.

So I created a simple Spring Boot backend while developing these changes.

@LuisValgoi what do you think we should proceed?

![react-query](https://user-images.githubusercontent.com/13343185/95379196-6d43d280-08bb-11eb-9942-b92b4d4ee9ab.gif)


## Config

Are you adding a configuration file?

- [ ] Have you updated the `publish` scripts?

## Testing

Include how the reviewer can test your PR.

## Automated Tests

- [ ] Select this if your code has automated Tests for it.

## References

- #21
